### PR TITLE
Add base problem implementation for faster usage with defaults.

### DIFF
--- a/src/main/kotlin/lgp/lib/BaseProblem.kt
+++ b/src/main/kotlin/lgp/lib/BaseProblem.kt
@@ -1,0 +1,196 @@
+package lgp.lib
+
+import lgp.core.environment.CoreModuleType
+import lgp.core.environment.DefaultValueProviders
+import lgp.core.environment.Environment
+import lgp.core.environment.ModuleContainer
+import lgp.core.environment.config.Config
+import lgp.core.environment.config.ConfigLoader
+import lgp.core.environment.config.JsonConfigLoader
+import lgp.core.environment.constants.ConstantLoader
+import lgp.core.environment.dataset.Dataset
+import lgp.core.environment.operations.DefaultOperationLoader
+import lgp.core.evolution.*
+import lgp.core.evolution.fitness.FitnessCase
+import lgp.core.evolution.fitness.FitnessFunction
+import lgp.core.evolution.fitness.FitnessFunctions
+import lgp.core.evolution.population.*
+import lgp.core.modules.ModuleInformation
+import java.util.*
+
+data class BaseProblemParameters(
+        val name: String,
+        val description: Description,
+        val configFilename: String? = null,
+        val config: Config? = null,
+        val constants: List<Double> = listOf(-1.0, 0.0, 1.0),
+        val operationClassNames: List<String> = listOf(
+                "lgp.lib.operations.Addition",
+                "lgp.lib.operations.Subtraction",
+                "lgp.lib.operations.Multiplication",
+                "lgp.lib.operations.Division"
+        ),
+        val defaultRegisterValue: Double = 1.0,
+        val fitnessFunction: FitnessFunction<Double> = FitnessFunctions.MSE(),
+        val tournamentSize: Int = 20,
+        val maximumSegmentLength: Int = 6,
+        val maximumCrossoverDistance: Int = 5,
+        val maximumSegmentLengthDifference: Int = 3,
+        val macroMutationInsertionRate: Double = 0.67,
+        val macroMutationDeletionRate: Double = 0.33,
+        val microRegisterMutationRate: Double = 0.4,
+        val microOperationMutationRate: Double = 0.4,
+        val runs: Int = 10
+)
+
+class BaseProblemException(message: String) : Exception(message)
+
+data class BaseProblemTestResult(val testResult: TestResult<Double>, val testFitness: Double)
+
+class BaseProblem(val params: BaseProblemParameters) : Problem<Double>() {
+    // Unpack values from parameters.
+    override val name = params.name
+
+    override val description = params.description
+
+    override val configLoader = when {
+        params.configFilename == null && params.config == null -> {
+            throw BaseProblemException(
+                    "Either the filename of a JSON file with configuration information" +
+                    "or a custom configuration object needs to be provided."
+            )
+        }
+        params.configFilename != null -> JsonConfigLoader(params.configFilename)
+        else -> {
+            // Fallback to default configuration
+            object : ConfigLoader {
+                override val information = ModuleInformation(
+                        "Default configuration loader."
+                )
+
+                override fun load(): Config {
+                    return params.config!!
+                }
+            }
+        }
+    }
+
+    override val constantLoader = object : ConstantLoader<Double> {
+        override val information = ModuleInformation(
+                description = "A base constant loader that provides a list of doubles."
+        )
+
+        override fun load(): List<Double> {
+            return params.constants
+        }
+    }
+
+    override val operationLoader = DefaultOperationLoader<Double>(params.operationClassNames)
+
+    override val defaultValueProvider = DefaultValueProviders.constantValueProvider(params.defaultRegisterValue)
+
+    override val fitnessFunction = params.fitnessFunction
+
+    override val registeredModules = ModuleContainer(
+            modules = mutableMapOf(
+                    CoreModuleType.InstructionGenerator to {
+                        BaseInstructionGenerator(environment)
+                    },
+                    CoreModuleType.ProgramGenerator to {
+                        BaseProgramGenerator(environment, sentinelTrueValue = 1.0)
+                    },
+                    CoreModuleType.SelectionOperator to {
+                        TournamentSelection(environment, tournamentSize = params.tournamentSize)
+                    },
+                    CoreModuleType.RecombinationOperator to {
+                        LinearCrossover(
+                                environment,
+                                maximumSegmentLength = params.maximumSegmentLength,
+                                maximumCrossoverDistance = params.maximumCrossoverDistance,
+                                maximumSegmentLengthDifference = params.maximumSegmentLengthDifference
+                        )
+                    },
+                    CoreModuleType.MacroMutationOperator to {
+                        MacroMutationOperator(
+                                environment,
+                                insertionRate = params.macroMutationInsertionRate,
+                                deletionRate = params.macroMutationDeletionRate
+                        )
+                    },
+                    CoreModuleType.MicroMutationOperator to {
+                        MicroMutationOperator(
+                                environment,
+                                registerMutationRate = params.microRegisterMutationRate,
+                                operatorMutationRate = params.microOperationMutationRate,
+                                constantMutationFunc = { v -> v + (Random().nextGaussian() * 1) }
+                        )
+                    }
+            )
+    )
+
+    var bestTrainingModel: EvolutionModel<Double>? = null
+
+    override fun initialiseEnvironment() {
+        this.environment = Environment(
+                this.configLoader,
+                this.constantLoader,
+                this.operationLoader,
+                this.defaultValueProvider,
+                this.fitnessFunction
+        )
+
+        this.environment.registerModules(this.registeredModules)
+    }
+
+    override fun initialiseModel() {
+        this.model = Models.SteadyState(this.environment)
+    }
+
+    override fun solve(): Solution<Double> {
+        throw BaseProblemException(
+                "BaseProblem can't be called directly to solve a problem. " +
+                "Use the train and test methods to train and test the model."
+        )
+    }
+
+    fun train(dataset: Dataset<Double>): TrainingResult<Double> {
+        try {
+            val trainer = Trainers.DistributedTrainer(environment, model, runs = this.params.runs)
+            val trainingResult = trainer.train(dataset)
+
+            // Choose the best model during training and save it so that it can be applied
+            // during testing.
+            this.bestTrainingModel = trainingResult.evaluations.zip(trainingResult.models)
+                    .sortedBy { (evaluation, _) -> evaluation.best.fitness }
+                    .map      { (_, model)      -> model }
+                    .first()
+
+            return trainingResult
+        } catch (ex: UninitializedPropertyAccessException) {
+            // The initialisation routines haven't been run.
+            throw ProblemNotInitialisedException(
+                    "The initialisation routines for this problem must be run before it can be solved."
+            )
+        }
+    }
+
+    fun test(dataset: Dataset<Double>): BaseProblemTestResult {
+        if (this.bestTrainingModel == null) {
+            throw BaseProblemException(
+                    "This problem has not had any models trained. The problem must be trained on a dataset " +
+                    "before testing can be performed."
+            )
+        }
+
+        val testResult = this.bestTrainingModel!!.test(dataset)
+
+        val testFitness = this.fitnessFunction(
+                testResult.predicted,
+                dataset.inputs.zip(dataset.outputs).map { (features, target) ->
+                    FitnessCase(features, target)
+                }
+        )
+
+        return BaseProblemTestResult(testResult, testFitness)
+    }
+}


### PR DESCRIPTION
The base problem provides a way to quickly get started solving a
problem. Instead of explicitly wiring up all the dependencies like you
would when defining a custom Problem impl, the base problem assumes a
bunch of defaults for you (letting parameters be set where available).

This commit closes issue #16.