### PR TITLE
Fix Kotlin usage example command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ kotlinc -cp LGP.jar -no-jdk -no-stdlib MyProblem.kt
 This will generate a class file in the directory called `MyProblemKt.class`. To interpret the class file using the Kotlin interpreter is simple:
 
 ```
-kotlin -cp LGP.jar MyProblemKt
+kotlin -cp LGP.jar:. MyProblemKt
 ```
 
 You should see the following output:

--- a/docs/source/guide/usage.rst
+++ b/docs/source/guide/usage.rst
@@ -66,7 +66,7 @@ This will generate a class file in the directory called ``MyProblemKt.class``. T
 
 .. code-block:: bash
 
-    kotlin -cp LGP.jar MyProblemKt
+    kotlin -cp LGP.jar:. MyProblemKt
 
 You should see the following output:
 


### PR DESCRIPTION
Adds minor fix for Kotlin usage example command, addressing issue #25.