### PR TITLE
Prevent CsvDatasetLoader from attempting to read data set each time load() is called.

### DIFF
--- a/src/main/kotlin/lgp/core/environment/dataset/CsvDatasetLoader.kt
+++ b/src/main/kotlin/lgp/core/environment/dataset/CsvDatasetLoader.kt
@@ -11,7 +11,8 @@ typealias Header = Array<String>
 typealias Row = Array<String>
 
 /**
- *
+ * Exception given when a CSV file that does not match the criteria the system expects
+ * is given to a [CsvDatasetLoader] instance.
  */
 class InvalidCsvFileException(message: String) : Exception(message)
 
@@ -130,8 +131,20 @@ class CsvDatasetLoader<out T> constructor(
         description = "A loader than can load data sets from CSV files."
     )
 }
+
+/**
+ * Provides a collection of parsing functions that can be used by a [CsvDatasetLoader] instance.
+ */
 object ParsingFunctions {
 
+    /**
+     * A feature parsing function that will create a sample of features by mapping each header row
+     * to its corresponding data row (using the feature indices provided). The function expects to
+     * be creating features with [Double] values.
+     *
+     * @param featureIndices The indices of any feature variables in the current [Row] being processed.
+     * @return A function that creates [Sample] instances from a CSV data row and header.
+     */
     fun indexedDoubleFeatureParsingFunction(featureIndices: IntRange): (Header, Row) -> Sample<Double> {
         return { header: Header, row: Row ->
             val features = row.zip(header)
@@ -148,8 +161,15 @@ object ParsingFunctions {
         }
     }
 
+    /**
+     * A target parsing function that simply takes a specific value from a [Row] using its index.
+     * The function expects to return target variables of the [Double] type.
+     *
+     * @param targetIndex The index of the target variable in the current [Row] being processed.
+     * @return A target parsing function that returns the target variable as a [Double] value.
+     */
     fun indexedDoubleTargetParsingFunction(targetIndex: Int): (Header, Row) -> Double {
-        return { header: Header, row: Row ->
+        return { _: Header, row: Row ->
             row[targetIndex].toDouble()
         }
     }

--- a/src/main/kotlin/lgp/core/environment/dataset/CsvDatasetLoader.kt
+++ b/src/main/kotlin/lgp/core/environment/dataset/CsvDatasetLoader.kt
@@ -11,6 +11,11 @@ typealias Header = Array<String>
 typealias Row = Array<String>
 
 /**
+ *
+ */
+class InvalidCsvFileException(message: String) : Exception(message)
+
+/**
  * Loads a collection of samples and their target values from a CSV file.
  *
  * @param T Type of the features in the samples.
@@ -99,6 +104,12 @@ class CsvDatasetLoader<out T> constructor(
 
         val reader = CSVReader(this.reader)
         val lines: MutableList<Array<String>> = reader.readAll()
+
+        // Make sure there is data before we continue. There should be at least two lines in the file
+        // (a header and one row of data). This check will let through a file with 2 data rows, but
+        // there is not much that can be done -- plus things will probably break down later on...
+        if (lines.size < 2)
+            throw InvalidCsvFileException("CSV file should have a header row and one or more data rows.")
 
         // Assumes the header is in the first row (a reasonable assumption with CSV files).
         val header = lines.removeAt(0)


### PR DESCRIPTION
Previously, there was a bug that occurred when `CsvDatasetLoader::load()` was called numerous times. The first call would succeed, but subsequent calls failed as the `Reader` instance passed could have exhausted its data source -- causing no data to be returned.

This caused issues with logic that parsed the CSV file as it made certain assumptions about the data that would be read (e.g. that the first line was the header).

This PR includes logic to cache the data set (to speed up subsequent loads), but also adds a fix to ensure that if invalid data is read in from a CSV file then the system handles it elegantly.