### PR TITLE
Add ability to export results using built-in helpers.

### DIFF
--- a/src/main/java/lgp/examples/java/SimpleFunctionProblem.java
+++ b/src/main/java/lgp/examples/java/SimpleFunctionProblem.java
@@ -206,6 +206,8 @@ public class SimpleFunctionProblem extends Problem<Double> {
                 this.getOperationLoader(),
                 this.getDefaultValueProvider(),
                 this.getFitnessFunction(),
+                // resultAggregator
+                null,
                 // randomStateSeed
                 null
         );

--- a/src/main/kotlin/lgp/core/environment/Environment.kt
+++ b/src/main/kotlin/lgp/core/environment/Environment.kt
@@ -3,6 +3,8 @@ package lgp.core.environment
 import lgp.core.environment.config.*
 import lgp.core.environment.constants.ConstantLoader
 import lgp.core.environment.operations.OperationLoader
+import lgp.core.evolution.ResultAggregator
+import lgp.core.evolution.ResultAggregators
 import lgp.core.evolution.fitness.FitnessFunction
 import lgp.core.evolution.instructions.Operation
 import lgp.core.evolution.registers.RegisterSet
@@ -67,12 +69,7 @@ enum class CoreModuleType : RegisteredModuleType {
     /**
      * A [FitnessContext] implementation.
      */
-    FitnessContext,
-
-    /**
-     * A [ResultsAggregator] implementation.
-     */
-    ResultsAggregator
+    FitnessContext
 }
 
 /**
@@ -226,6 +223,8 @@ open class Environment<T> {
      */
     var container: ModuleContainer<T>
 
+    val resultAggregator: ResultAggregator<T>
+
     /**
      * Builds an environment with the specified construction components.
      *
@@ -246,6 +245,7 @@ open class Environment<T> {
             operationLoader: OperationLoader<T>,
             defaultValueProvider: DefaultValueProvider<T>,
             fitnessFunction: FitnessFunction<T>,
+            resultAggregator: ResultAggregator<T>? = null,
             randomStateSeed: Long? = null
     ) {
 
@@ -255,6 +255,7 @@ open class Environment<T> {
         this.defaultValueProvider = defaultValueProvider
         this.fitnessFunction = fitnessFunction
         this.randomStateSeed = randomStateSeed
+        this.resultAggregator = resultAggregator ?: ResultAggregators.DefaultResultAggregator()
 
         // Determine whether we need to seed the RNG or not.
         when (this.randomStateSeed) {
@@ -288,6 +289,8 @@ open class Environment<T> {
 
         // Make sure the modules have access to this environment.
         this.container.environment = this
+
+        // Register the default result aggregator
     }
 
     private fun initialiseRegisterSet() {
@@ -387,6 +390,7 @@ open class Environment<T> {
                 this.operationLoader,
                 this.defaultValueProvider,
                 this.fitnessFunction,
+                this.resultAggregator,
                 this.randomState.nextLong()
         )
 

--- a/src/main/kotlin/lgp/core/environment/Environment.kt
+++ b/src/main/kotlin/lgp/core/environment/Environment.kt
@@ -67,7 +67,12 @@ enum class CoreModuleType : RegisteredModuleType {
     /**
      * A [FitnessContext] implementation.
      */
-    FitnessContext
+    FitnessContext,
+
+    /**
+     * A [ResultsAggregator] implementation.
+     */
+    ResultsAggregator
 }
 
 /**

--- a/src/main/kotlin/lgp/core/environment/Environment.kt
+++ b/src/main/kotlin/lgp/core/environment/Environment.kt
@@ -255,6 +255,7 @@ open class Environment<T> {
         this.defaultValueProvider = defaultValueProvider
         this.fitnessFunction = fitnessFunction
         this.randomStateSeed = randomStateSeed
+        // If no result aggregator is provided then use the default aggregator which doesn't collect results.
         this.resultAggregator = resultAggregator ?: ResultAggregators.DefaultResultAggregator()
 
         // Determine whether we need to seed the RNG or not.
@@ -289,8 +290,6 @@ open class Environment<T> {
 
         // Make sure the modules have access to this environment.
         this.container.environment = this
-
-        // Register the default result aggregator
     }
 
     private fun initialiseRegisterSet() {

--- a/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
+++ b/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
@@ -40,9 +40,15 @@ abstract class ResultAggregator<T> : Module {
      */
     abstract fun addAll(results: List<ExportableResult<T>>)
 
+    /**
+     * Signals that no more results will be collected.
+     */
     abstract fun close()
 }
 
+/**
+ * A collection of built-in [ResultAggregator] implementations.
+ */
 class ResultAggregators {
     /**
      * A simple result aggregator that builds an internal collection of results.
@@ -266,8 +272,10 @@ object ResultOutputProviders {
 
     /**
      * Provides the ability to write a table of results to a text file.
+     *
+     * @param filename A file to write text results to.
      */
-    class RawResultTableOutputProvider<T>(val filename: String): ResultOutputProvider<T> {
+    class RawResultTableOutputProvider<T>(private val filename: String): ResultOutputProvider<T> {
 
         private val writer = Files.newBufferedWriter(Paths.get(this.filename))
 
@@ -280,8 +288,10 @@ object ResultOutputProviders {
 
     /**
      * Provides the ability to write results to a CSV file.
+     *
+     * @param filename A file to write CSV data to.
      */
-    class CsvResultOutputProvider<T>(val filename: String) : ResultOutputProvider<T> {
+    class CsvResultOutputProvider<T>(private val filename: String) : ResultOutputProvider<T> {
 
         private val csvWriter: CSVWriter = CSVWriter(
                 Files.newBufferedWriter(Paths.get(this.filename))

--- a/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
+++ b/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
@@ -1,0 +1,166 @@
+package lgp.core.evolution
+
+import com.opencsv.CSVWriter
+import lgp.core.environment.Environment
+import lgp.core.modules.Module
+import lgp.core.modules.ModuleInformation
+import java.nio.file.Files
+import java.nio.file.Paths
+
+/**
+ * Represents a result that is able to be exported from the system.
+ *
+ * The type of result that it represents is flexible and will depend on which part of the
+ * system it comes from. The idea of being *exportable* means that the internal representation
+ * can be whatever, as long as it has a way to be exported to a list of string pairs.
+ */
+interface ExportableResult<T> {
+
+    /**
+     * Creates an exportable representation of this result.
+     */
+    fun export(): List<Pair<String, String>>
+}
+
+abstract class ResultAggregator<T>(val environment: Environment<T>) : Module {
+    abstract val results: List<ExportableResult<T>>
+
+    abstract fun add(result: ExportableResult<T>)
+    abstract fun addAll(results: List<ExportableResult<T>>)
+
+}
+
+/**
+ * A simple result source that builds an internal collection of results.
+ *
+ * This implementation is intended to be used within the system, as part of the environment context. Such a
+ * usage will allow for internal components to aggregate their results to one central location.
+ */
+class BaseResultAggregator<T>(environment: Environment<T>) : ResultAggregator<T>(environment) {
+
+    override val results: MutableList<ExportableResult<T>> = mutableListOf()
+
+    /**
+     * Add a single result.
+     */
+    override fun add(result: ExportableResult<T>) {
+        this.results.add(result)
+    }
+
+    /**
+     * Add a collection of results.
+     */
+    override fun addAll(results: List<ExportableResult<T>>) {
+        this.results.addAll(results)
+    }
+
+    /**
+     * Clear all stored results.
+     */
+    fun clear() {
+        this.results.clear()
+    }
+
+    override fun toString(): String {
+        if (this.results.isEmpty())
+            return "No results."
+
+        val table = StringBuilder()
+        val firstResult = this.results.first().export()
+        val header = firstResult.map { result -> result.first }.toList()
+
+        header.map { key -> table.append("%-28s".format(key)) }
+        table.appendln()
+
+        this.results.forEach { result ->
+            val exported = result.export()
+
+            exported.map { value -> table.append("%-28s".format(value.second)) }
+            table.append('\n')
+        }
+
+        return table.toString()
+    }
+
+    /**
+     * Provides information about the module.
+     */
+    override val information = ModuleInformation(
+            description = "Aggregates results that are able to be exported."
+    )
+}
+
+/**
+ * Provides the ability to output results from a [ResultSource].
+ */
+interface ResultOutputProvider<T> {
+    fun writeResultsFrom(source: ResultAggregator<T>)
+}
+
+/**
+ * A collection of [ResultOutputProvider] implementations for common scenarios.
+ */
+object ResultOutputProviders {
+
+    /**
+     *
+     */
+    class RawResultTableOutputProvider<T>(val filename: String): ResultOutputProvider<T> {
+
+        private val writer = Files.newBufferedWriter(Paths.get(this.filename))
+
+        override fun writeResultsFrom(source: ResultAggregator<T>) {
+            writer.use { out ->
+                out.write(source.toString())
+            }
+        }
+    }
+
+    /**
+     * Provides the ability to write results to a CSV file.
+     */
+    class CsvResultOutputProvider<T>(val filename: String) : ResultOutputProvider<T> {
+
+        private val csvWriter: CSVWriter = CSVWriter(
+                Files.newBufferedWriter(Paths.get(this.filename))
+        )
+
+        override fun writeResultsFrom(source: ResultAggregator<T>) {
+            // Is there any results?
+            if (source.results.isEmpty())
+                return
+
+            // Grab header information
+            val first = source.results.first().export()
+            val header = first.map { (name, _) -> name }
+
+            // Write header row
+            this.csvWriter.writeNext(header.toTypedArray())
+
+            // Write value rows
+            source.results.map { result ->
+                val exported = result.export()
+                val values = exported.map { (_, value) -> value }
+
+                this.csvWriter.writeNext(values.toTypedArray())
+            }
+
+            // Done!
+            this.csvWriter.flush()
+        }
+    }
+}
+
+/**
+ * Exports results using a given [ResultOutputProvider].
+ */
+class ResultExporter<T>(val outputProvider: ResultOutputProvider<T>) {
+
+    /**
+     * Exports [results] using [outputProvider].
+     */
+    fun export(results: ResultAggregator<T>) {
+        this.outputProvider.writeResultsFrom(results)
+    }
+
+}

--- a/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
+++ b/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
@@ -197,7 +197,10 @@ class ResultAggregators {
                 return
 
             this.outputProvider.writeResultsFrom(this)
-            this.results.clear()
+            
+            synchronized(this) {
+                this.results.clear()
+            }
         }
 
         /**
@@ -210,7 +213,10 @@ class ResultAggregators {
                     // Need to flush buffer to output provider
                     this.log("Flushing results buffer (size = ${results.size})...")
                     this.outputProvider.writeResultsFrom(this)
-                    this.results.clear()
+
+                    synchronized(this) {
+                        this.results.clear()
+                    }
                 }
             }
         }

--- a/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
+++ b/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
@@ -1,7 +1,6 @@
 package lgp.core.evolution
 
 import com.opencsv.CSVWriter
-import lgp.core.environment.Environment
 import lgp.core.modules.Module
 import lgp.core.modules.ModuleInformation
 import java.nio.file.Files
@@ -22,78 +21,241 @@ interface ExportableResult<T> {
     fun export(): List<Pair<String, String>>
 }
 
-abstract class ResultAggregator<T>(val environment: Environment<T>) : Module {
+/**
+ * A module that can collect [ExportableResult] instances for later export from the system.
+ */
+abstract class ResultAggregator<T> : Module {
+    /**
+     * A collection of [ExportableResult] instances.
+     */
     abstract val results: List<ExportableResult<T>>
 
+    /**
+     * Add an [ExportableResult].
+     */
     abstract fun add(result: ExportableResult<T>)
+
+    /**
+     * Add a collection of [ExportableResult] instances in a batch aggregation.
+     */
     abstract fun addAll(results: List<ExportableResult<T>>)
 
+    abstract fun close()
 }
 
-/**
- * A simple result source that builds an internal collection of results.
- *
- * This implementation is intended to be used within the system, as part of the environment context. Such a
- * usage will allow for internal components to aggregate their results to one central location.
- */
-class BaseResultAggregator<T>(environment: Environment<T>) : ResultAggregator<T>(environment) {
-
-    override val results: MutableList<ExportableResult<T>> = mutableListOf()
-
+class ResultAggregators {
     /**
-     * Add a single result.
+     * A simple result aggregator that builds an internal collection of results.
+     *
+     * Care must be taken with this aggregator, as it will keep all results in memory and only
+     * relieve results once cleared. Results should either be exported regularly or the number
+     * of results aggregated should be limited. Alternatively, another aggregator that flushes
+     * results automatically could be used.
+     *
+     * Note that if using this implementation in a multi-threaded environment, there is no guarantee
+     * about the order of the results produced. The built-in [Trainers] which contain result aggregation
+     * logic ensure that results are grouped per-run, but there it is not certain that the runs will be
+     * in order.
      */
-    override fun add(result: ExportableResult<T>) {
-        this.results.add(result)
-    }
+    class InMemoryResultAggregator<T> : ResultAggregator<T>() {
 
-    /**
-     * Add a collection of results.
-     */
-    override fun addAll(results: List<ExportableResult<T>>) {
-        this.results.addAll(results)
-    }
+        override val results: MutableList<ExportableResult<T>> = mutableListOf()
 
-    /**
-     * Clear all stored results.
-     */
-    fun clear() {
-        this.results.clear()
-    }
-
-    override fun toString(): String {
-        if (this.results.isEmpty())
-            return "No results."
-
-        val table = StringBuilder()
-        val firstResult = this.results.first().export()
-        val header = firstResult.map { result -> result.first }.toList()
-
-        header.map { key -> table.append("%-28s".format(key)) }
-        table.appendln()
-
-        this.results.forEach { result ->
-            val exported = result.export()
-
-            exported.map { value -> table.append("%-28s".format(value.second)) }
-            table.append('\n')
+        /**
+         * Add a single result.
+         */
+        override fun add(result: ExportableResult<T>) {
+            this.results.add(result)
         }
 
-        return table.toString()
+        /**
+         * Add a collection of results.
+         */
+        override fun addAll(results: List<ExportableResult<T>>) {
+            this.results.addAll(results)
+        }
+
+        /**
+         * Clear all stored results.
+         */
+        override fun close() {
+            this.results.clear()
+        }
+
+        /**
+         * Returns a representation of any currently aggregated results in a simple table format.
+         */
+        override fun toString(): String {
+            if (this.results.isEmpty())
+                return "No results."
+
+            val table = StringBuilder()
+            val firstResult = this.results.first().export()
+            val header = firstResult.map { result -> result.first }.toList()
+
+            header.map { key -> table.append("%-28s".format(key)) }
+            table.appendln()
+
+            this.results.forEach { result ->
+                val exported = result.export()
+
+                exported.map { value -> table.append("%-28s".format(value.second)) }
+                table.append('\n')
+            }
+
+            return table.toString()
+        }
+
+        /**
+         * Provides information about the module.
+         */
+        override val information = ModuleInformation(
+                description = "Aggregates results that are able to be exported."
+        )
     }
 
     /**
-     * Provides information about the module.
+     * A [ResultAggregator] that buffers results and flushes to a CSV output regularly.
+     *
+     * This implementation will avoid using large amounts of memory as any results aggregated
+     * are regularly written out to file, instead of being kept in memory. Currently, the only
+     * supported [ResultOutputProvider] is [ResultOutputProviders.CsvResultOutputProvider] as
+     * no other output provider implementations support the buffered output required.
+     *
+     * Note that the buffering is done in a thread-safe way to ensure that there is no contention
+     * between threads when results are being added/output simultaneously. Despite this, there is no
+     * guarantee that the order of the results will be sequential in a multi-threaded environment. The
+     * built-in [Trainers] ensure that the results will be grouped by their run however.
+     *
+     * @param outputProvider A [ResultOutputProviders.CsvResultOutputProvider] instance.
+     * @param bufferSize How many results to keep in memory before writing to [outputProvider].
+     * @param verbose Writes detailed output about any buffering operations to standard out.
      */
-    override val information = ModuleInformation(
-            description = "Aggregates results that are able to be exported."
-    )
+    class BufferedResultAggregator<T>(
+            private val outputProvider: ResultOutputProviders.CsvResultOutputProvider<T>,
+            private val bufferSize: Int = 100,
+            private val verbose: Boolean = false
+    ) : ResultAggregator<T>() {
+
+        override val results: MutableList<ExportableResult<T>> = mutableListOf()
+
+        /**
+         * Adds a single [ExportableResult].
+         */
+        override fun add(result: ExportableResult<T>) {
+            this.maybeFlushBuffer(1)
+
+            synchronized(this) {
+                this.results.add(result)
+            }
+        }
+
+        /**
+         * Adds a collection of [ExportableResult] instances.
+         */
+        override fun addAll(results: List<ExportableResult<T>>) {
+            this.maybeFlushBuffer(results.size)
+
+            this.log("Adding ${results.size} results...")
+            if (results.size > this.bufferSize) {
+                this.addInChunks(results)
+                return
+            }
+
+            synchronized(this) {
+                this.results.addAll(results)
+            }
+        }
+
+        /**
+         * Internal method used to write a collection of [ExportableResult] instances in chunks.
+         *
+         * Writing in chunks will be more efficient than over-filling the buffer and having to flush
+         * a large amount of results in one go.
+         */
+        private fun addInChunks(results: List<ExportableResult<T>>) {
+            this.log("Adding in chunks...")
+
+            results.chunked(this.bufferSize).map { chunk ->
+                this.log("Adding chunk with ${chunk.size} results...")
+                this.addAll(chunk)
+            }
+        }
+
+        /**
+         * Writes any remaining buffered results.
+         */
+        override fun close() {
+            this.log("Writing any remaining buffered results...")
+            if (results.isEmpty())
+                return
+
+            this.outputProvider.writeResultsFrom(this)
+            this.results.clear()
+        }
+
+        /**
+         * Determines if the buffer needs flushing and flushes if necessary.
+         */
+        private fun maybeFlushBuffer(count: Int) {
+            when {
+                (results.size + count) < this.bufferSize -> return
+                else -> {
+                    // Need to flush buffer to output provider
+                    this.log("Flushing results buffer (size = ${results.size})...")
+                    this.outputProvider.writeResultsFrom(this)
+                    this.results.clear()
+                }
+            }
+        }
+
+        private fun log(message: String) {
+            if (this.verbose)
+                println(message)
+        }
+
+        /**
+         * Provides information about the module.
+         */
+        override val information = ModuleInformation(
+                description = "Aggregates results that are able to be exported."
+        )
+    }
+
+    /**
+     * A [ResultAggregator] implementation which does nothing.
+     *
+     * Useful for situations where it is not required to aggregate results and export to an output source.
+     */
+    class DefaultResultAggregator<T> : ResultAggregator<T>() {
+        override val results = emptyList<ExportableResult<T>>()
+
+        override fun add(result: ExportableResult<T>) {
+            // No op.
+        }
+
+        override fun addAll(results: List<ExportableResult<T>>) {
+            // No op.
+        }
+
+        override fun close() {
+            // No op.
+        }
+
+        override val information = ModuleInformation(
+            "Default aggregator which simply does nothing."
+        )
+    }
 }
 
 /**
- * Provides the ability to output results from a [ResultSource].
+ * Provides the ability to output results from a [ResultAggregator].
  */
 interface ResultOutputProvider<T> {
+
+    /**
+     * Writes any results from [source] to some output destination.
+     */
     fun writeResultsFrom(source: ResultAggregator<T>)
 }
 
@@ -103,7 +265,7 @@ interface ResultOutputProvider<T> {
 object ResultOutputProviders {
 
     /**
-     *
+     * Provides the ability to write a table of results to a text file.
      */
     class RawResultTableOutputProvider<T>(val filename: String): ResultOutputProvider<T> {
 
@@ -125,20 +287,28 @@ object ResultOutputProviders {
                 Files.newBufferedWriter(Paths.get(this.filename))
         )
 
+        private var headerHasBeenWriten: Boolean = false
+
         override fun writeResultsFrom(source: ResultAggregator<T>) {
+            // Act on a view of the results to avoid thread-safety issues
+            val results = source.results.toList()
+
             // Is there any results?
-            if (source.results.isEmpty())
+            if (results.isEmpty())
                 return
 
             // Grab header information
-            val first = source.results.first().export()
-            val header = first.map { (name, _) -> name }
+            if (!headerHasBeenWriten) {
+                val first = results.first().export()
+                val header = first.map { (name, _) -> name }
 
-            // Write header row
-            this.csvWriter.writeNext(header.toTypedArray())
+                // Write header row
+                this.csvWriter.writeNext(header.toTypedArray())
+                this.headerHasBeenWriten = true
+            }
 
             // Write value rows
-            source.results.map { result ->
+            results.map { result ->
                 val exported = result.export()
                 val values = exported.map { (_, value) -> value }
 
@@ -151,16 +321,3 @@ object ResultOutputProviders {
     }
 }
 
-/**
- * Exports results using a given [ResultOutputProvider].
- */
-class ResultExporter<T>(val outputProvider: ResultOutputProvider<T>) {
-
-    /**
-     * Exports [results] using [outputProvider].
-     */
-    fun export(results: ResultAggregator<T>) {
-        this.outputProvider.writeResultsFrom(results)
-    }
-
-}

--- a/src/main/kotlin/lgp/core/evolution/Trainer.kt
+++ b/src/main/kotlin/lgp/core/evolution/Trainer.kt
@@ -136,7 +136,7 @@ object Trainers {
             override fun call(): EvolutionResult<TProgram> {
                 val result = this.model.train(this.dataset)
 
-                // Aggregate results
+                // Aggregate results for this thread.
                 val generationalResults = result.statistics.map { generation ->
                     RunBasedExportableResult<TProgram>(this.run, generation)
                 }
@@ -154,7 +154,9 @@ object Trainers {
             // Submit all tasks to the executor. Each model will have a task created for it
             // that the executor is responsible for executing.
             val futures = this.models.mapIndexed { run, model ->
-                this.executor.submit(ModelTrainerTask(run, model, dataset, this.aggregator))
+                this.executor.submit(
+                    ModelTrainerTask(run, model, dataset, this.aggregator)
+                )
             }
 
             // Collect the results -- waiting when necessary.

--- a/src/main/kotlin/lgp/core/evolution/population/EvolutionModel.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/EvolutionModel.kt
@@ -2,7 +2,6 @@ package lgp.core.evolution.population
 
 import lgp.core.environment.Environment
 import lgp.core.environment.dataset.Dataset
-import lgp.core.evolution.ExportableResult
 import lgp.core.modules.Module
 
 /**

--- a/src/main/kotlin/lgp/core/evolution/population/EvolutionModel.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/EvolutionModel.kt
@@ -2,6 +2,7 @@ package lgp.core.evolution.population
 
 import lgp.core.environment.Environment
 import lgp.core.environment.dataset.Dataset
+import lgp.core.evolution.ExportableResult
 import lgp.core.modules.Module
 
 /**

--- a/src/main/kotlin/lgp/core/evolution/population/Models.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/Models.kt
@@ -3,12 +3,27 @@ package lgp.core.evolution.population
 import lgp.core.environment.CoreModuleType
 import lgp.core.environment.Environment
 import lgp.core.environment.dataset.Dataset
+import lgp.core.evolution.ExportableResult
 import lgp.core.evolution.fitness.Evaluation
 import lgp.core.evolution.fitness.FitnessEvaluator
 import lgp.core.modules.ModuleInformation
 import java.util.Random
 import kotlin.concurrent.thread
 import kotlin.streams.toList
+
+class RunBasedExportableResult<T>(val run: Int, val statistics: EvolutionStatistics) : ExportableResult<T> {
+    override fun export(): List<Pair<String, String>> {
+        val out = mutableListOf(
+                Pair("run", this.run.toString())
+        )
+
+        out.addAll(statistics.data.map { (name, value) ->
+            Pair(name, value.toString())
+        })
+
+        return out
+    }
+}
 
 /**
  * A collection of built-in evolution models.

--- a/src/main/kotlin/lgp/core/evolution/population/Models.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/Models.kt
@@ -11,7 +11,23 @@ import java.util.Random
 import kotlin.concurrent.thread
 import kotlin.streams.toList
 
-class RunBasedExportableResult<T>(val run: Int, val statistics: EvolutionStatistics) : ExportableResult<T> {
+/**
+ * An [ExportableResult] implementation that represents evolution statistics for a particular run.
+ *
+ * Because evolution statistics are collected on a per-generation basis, this type of exportable result
+ * collects data on each generation for each run.
+ *
+ * @param run The run this result relates to.
+ * @param statistics Evolution statistics for a particular generation.
+ */
+class RunBasedExportableResult<T>(
+    val run: Int,
+    private val statistics: EvolutionStatistics
+) : ExportableResult<T> {
+
+    /**
+     * Exports this result as a mapping of statistic names to statistic values.
+     */
     override fun export(): List<Pair<String, String>> {
         val out = mutableListOf(
                 Pair("run", this.run.toString())

--- a/src/main/kotlin/lgp/examples/SimpleFunction.kt
+++ b/src/main/kotlin/lgp/examples/SimpleFunction.kt
@@ -159,7 +159,10 @@ class SimpleFunctionProblem : Problem<Double>() {
                 this.constantLoader,
                 this.operationLoader,
                 this.defaultValueProvider,
-                this.fitnessFunction
+                this.fitnessFunction,
+                ResultAggregators.BufferedResultAggregator(
+                        ResultOutputProviders.CsvResultOutputProvider("/Users/jedsimson/Desktop/results.csv")
+                )
         )
 
         this.environment.registerModules(this.registeredModules)

--- a/src/main/kotlin/lgp/examples/SimpleFunction.kt
+++ b/src/main/kotlin/lgp/examples/SimpleFunction.kt
@@ -149,6 +149,9 @@ class SimpleFunctionProblem : Problem<Double>() {
                     },
                     CoreModuleType.FitnessContext to { environment ->
                         SingleOutputFitnessContext(environment)
+                    },
+                    CoreModuleType.ResultsAggregator to { environment ->
+                        BaseResultAggregator(environment)
                     }
             )
     )
@@ -193,6 +196,13 @@ class SimpleFunction {
             problem.initialiseModel()
             val solution = problem.solve()
             val simplifier = BaseProgramSimplifier<Double>()
+            val resultsOutput = ResultOutputProviders.CsvResultOutputProvider<Double>(
+                filename = "/Users/jedsimson/Desktop/results.csv"
+            )
+
+            resultsOutput.writeResultsFrom(
+                problem.environment.registeredModule(CoreModuleType.ResultsAggregator)
+            )
 
             println("Results:")
 

--- a/src/main/kotlin/lgp/examples/SimpleFunction.kt
+++ b/src/main/kotlin/lgp/examples/SimpleFunction.kt
@@ -149,9 +149,6 @@ class SimpleFunctionProblem : Problem<Double>() {
                     },
                     CoreModuleType.FitnessContext to { environment ->
                         SingleOutputFitnessContext(environment)
-                    },
-                    CoreModuleType.ResultsAggregator to { environment ->
-                        BaseResultAggregator(environment)
                     }
             )
     )
@@ -196,13 +193,6 @@ class SimpleFunction {
             problem.initialiseModel()
             val solution = problem.solve()
             val simplifier = BaseProgramSimplifier<Double>()
-            val resultsOutput = ResultOutputProviders.CsvResultOutputProvider<Double>(
-                filename = "/Users/jedsimson/Desktop/results.csv"
-            )
-
-            resultsOutput.writeResultsFrom(
-                problem.environment.registeredModule(CoreModuleType.ResultsAggregator)
-            )
 
             println("Results:")
 


### PR DESCRIPTION
This PR adds support in the system for collecting and exporting results from experiments.

Previously, one would have to implement this logic manually and use it across experiments, which is not a seamless workflow. The helper classes provided by this PR will allow users to wire up results aggregation and results exportation easily, without having to worry about details of how to implement such logic.

