### PR TITLE
Make ResultAggregator implement AutoCloseable interface.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,9 +2,9 @@ group 'LGP'
 version '1.2'
 
 buildscript {
-    ext.kotlin_version = '1.2.21'
-    ext.dokka_version = '0.9.15'
-    ext.kotlinx_coroutines_version = '0.22.2'
+    ext.kotlin_version = '1.2.31'
+    ext.dokka_version = '0.9.16'
+    ext.kotlinx_coroutines_version = '0.22.5'
 
     repositories {
         mavenCentral()
@@ -33,10 +33,10 @@ dependencies {
     compile "org.jetbrains.kotlinx:kotlinx-coroutines-core:$kotlinx_coroutines_version"
 
     // https://mvnrepository.com/artifact/com.google.code.gson/gson
-    compile group: 'com.google.code.gson', name: 'gson', version: '1.7.2'
+    compile group: 'com.google.code.gson', name: 'gson', version: '2.8.2'
 
     // https://mvnrepository.com/artifact/com.opencsv/opencsv
-    compile group: 'com.opencsv', name: 'opencsv', version: '3.7'
+    compile group: 'com.opencsv', name: 'opencsv', version: '4.1'
 
     testCompile group: 'junit', name: 'junit', version: '4.12'
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-branch_name=$1
+branch_name=$(echo $1 | sed -e 's/\//-/g')
 tag_name=$2
 now=$(date +%Y-%m-%d)
 version=$(gradle -q printVersion)

--- a/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
+++ b/src/main/kotlin/lgp/core/evolution/ResultsExporter.kt
@@ -24,7 +24,7 @@ interface ExportableResult<T> {
 /**
  * A module that can collect [ExportableResult] instances for later export from the system.
  */
-abstract class ResultAggregator<T> : Module {
+abstract class ResultAggregator<T> : Module, AutoCloseable {
     /**
      * A collection of [ExportableResult] instances.
      */
@@ -39,11 +39,6 @@ abstract class ResultAggregator<T> : Module {
      * Add a collection of [ExportableResult] instances in a batch aggregation.
      */
     abstract fun addAll(results: List<ExportableResult<T>>)
-
-    /**
-     * Signals that no more results will be collected.
-     */
-    abstract fun close()
 }
 
 /**

--- a/src/main/kotlin/lgp/examples/SimpleFunction.kt
+++ b/src/main/kotlin/lgp/examples/SimpleFunction.kt
@@ -161,7 +161,7 @@ class SimpleFunctionProblem : Problem<Double>() {
                 this.defaultValueProvider,
                 this.fitnessFunction,
                 ResultAggregators.BufferedResultAggregator(
-                        ResultOutputProviders.CsvResultOutputProvider("/Users/jedsimson/Desktop/results.csv")
+                        ResultOutputProviders.CsvResultOutputProvider("results.csv")
                 )
         )
 


### PR DESCRIPTION
This PR implements the behaviour mentioned in issue #38. The implementation of the API itself was simple -- but required some changes to the Kotlin version.

Because I was updating the buildscript anyway, I updated a few other dependency versions to try and stay up-to-date.

Two bugs were also fixed as part of this work:
- Automated feature builds couldn't handle branch names with slashes.
- `SimpleFunction` example referenced a local file path.