### PR TITLE
Refactor mutation operators.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,19 @@ dependencies {
     compile 'com.fasterxml.jackson.module:jackson-module-kotlin:2.9.2'
     compile 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.9.2'
 }
+
 kotlin {
     experimental {
         coroutines "enable"
     }
+}
+
+tasks.withType(JavaCompile) {
+    options.compilerArgs << "-Xlint:unchecked"      \
+                         << "-Xlint:all"            \
+                         << "-Xlint:-processing"    \
+                         << "-Xlint:-serial"        \
+                         << "-Werror"
 }
 
 task dokkaApiHtml(type: org.jetbrains.dokka.gradle.DokkaTask) {

--- a/src/main/java/lgp/examples/java/SimpleFunction.java
+++ b/src/main/java/lgp/examples/java/SimpleFunction.java
@@ -13,13 +13,13 @@ import java.util.Map;
 public class SimpleFunction {
 
     public static void main(String[] args) {
-        Problem problem = new SimpleFunctionProblem();
+        Problem<Double> problem = new SimpleFunctionProblem();
 
         problem.initialiseEnvironment();
         problem.initialiseModel();
 
         SimpleFunctionSolution solution = (SimpleFunctionSolution) problem.solve();
-        BaseProgramSimplifier simplifier = new BaseProgramSimplifier();
+        BaseProgramSimplifier<Double> simplifier = new BaseProgramSimplifier<>();
 
         System.out.println("Results:");
         int run = 0;

--- a/src/main/java/lgp/examples/java/SimpleFunctionProblem.java
+++ b/src/main/java/lgp/examples/java/SimpleFunctionProblem.java
@@ -183,7 +183,7 @@ public class SimpleFunctionProblem extends Problem<Double> {
                 Double x = it.next();
                 
                 samples.add(
-                        new Sample(Arrays.asList(new Feature("x", x)))
+                        new Sample<>(Collections.singletonList(new Feature<>("x", x)))
                 );
             }
 

--- a/src/main/kotlin/lgp/core/evolution/population/Models.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/Models.kt
@@ -567,7 +567,7 @@ object Models {
                 var best = initialEvaluations.sortedBy(Evaluation<TProgram>::fitness).first()
                 this.bestIndividual = best.individual
 
-                (0 until numGenerations).forEach { gen ->
+                (0 until numGenerations).forEach { _ ->
                     val children = this.select.select(this.individuals)
 
                     children.pairwise().map { (mother, father) ->

--- a/src/main/kotlin/lgp/core/evolution/population/MutationOperator.kt
+++ b/src/main/kotlin/lgp/core/evolution/population/MutationOperator.kt
@@ -77,11 +77,14 @@ class MacroMutationOperator<T>(
 
         // 1. Randomly select macro mutation type insertion | deletion with probability
         // p_ins | p_del and with p_ins + p_del = 1
-        val mutationType = if (random.nextDouble() < this.insertionRate) MacroMutationType.Insertion
-                           else MacroMutationType.Deletion
+        val mutationType = if (random.nextDouble() < this.insertionRate) {
+            MacroMutationType.Insertion
+        } else {
+            MacroMutationType.Deletion
+        }
 
         // 2. Randomly select an instruction at a position i (mutation point) in program gp.
-        val i = random.randInt(0, programLength - 1)
+        val mutationPoint = random.randInt(0, programLength - 1)
 
         // 3. If len(gp) < l_max and (insertion or len(gp) = l_min) then
         if (programLength < maximumProgramLength &&
@@ -90,22 +93,22 @@ class MacroMutationOperator<T>(
             // We can avoid running algorithm 3.1 like in the literature by
             // just searching for effective calculation registers and making
             // sure we choose an effective register for our mutation
-            val effectiveRegisters = findEffectiveCalculationRegisters(individual, i)
+            val effectiveRegisters = findEffectiveCalculationRegisters(individual, mutationPoint)
             val instruction = this.instructionGenerator.generateInstruction()
 
             // Can only perform a mutation if there is an effective register to choose from.
             if (effectiveRegisters.isNotEmpty()) {
                 instruction.destination = random.choice(effectiveRegisters)
 
-                individual.instructions.add(i, instruction)
+                individual.instructions.add(mutationPoint, instruction)
             }
         }
         else if (programLength > minimumProgramLength &&
-                (mutationType == MacroMutationType.Deletion || programLength == maximumProgramLength)) {
+                    (mutationType == MacroMutationType.Deletion || programLength == maximumProgramLength)) {
 
             // 4.
             // (a) Select an effective instruction i (if existent)
-            if (individual.effectiveInstructions.size > 0) {
+            if (individual.effectiveInstructions.isNotEmpty()) {
                 val instruction = random.choice(individual.effectiveInstructions)
 
                 // (b) Delete instruction i
@@ -183,8 +186,9 @@ class MicroMutationOperator<T>(
         individual.findEffectiveProgram()
 
         // Can't do anything if there are no effective instructions
-        if (individual.effectiveInstructions.size == 0)
+        if (individual.effectiveInstructions.isEmpty()) {
             return
+        }
 
         val instruction = random.choice(individual.effectiveInstructions)
 
@@ -210,75 +214,83 @@ class MicroMutationOperator<T>(
         when (mutationType) {
             // 3. If register mutation then
             MicroMutationType.Register -> {
-                val choices = mutableListOf(instruction.destination)
-                choices.addAll(instruction.operands)
+                val registerPositions = mutableListOf(instruction.destination)
+                registerPositions.addAll(instruction.operands)
 
                 // (a) Randomly select a register position destination | operand
-                val reg = random.choice(choices)
+                val register = random.choice(registerPositions)
 
-                if (reg == instruction.destination) {
+                if (register == instruction.destination) {
                     // (b) If destination register then select a different (effective)
                     // destination register (applying Algorithm 3.1)
-                    val i = individual.instructions.indexOf(instruction)
+                    val instructionPosition = individual.instructions.indexOf(instruction)
 
                     // Use our shortcut version of Algorithm 3.1.
-                    val effectiveRegisters = findEffectiveCalculationRegisters(individual, i)
+                    val effectiveRegisters = findEffectiveCalculationRegisters(individual, instructionPosition)
 
-                    instruction.destination = if (effectiveRegisters.isNotEmpty()) random.choice(effectiveRegisters)
-                                              else instruction.destination
+                    instruction.destination = if (effectiveRegisters.isNotEmpty()) {
+                        random.choice(effectiveRegisters)
+                    } else {
+                        instruction.destination
+                    }
                 } else {
                     // (c) If operand register then select a different constant | register with probability
                     // p_const | 1 - p_const
-                    val idx = instruction.operands.indexOf(reg)
+                    val operand = instruction.operands.indexOf(register)
 
-                    if (random.nextDouble() < constantsRate) {
-                        instruction.operands[idx] = registerGenerator.next(RegisterType.Constant).first().index
+                    val replacementRegister = if (random.nextDouble() < constantsRate) {
+                        registerGenerator.next(RegisterType.Constant).first()
                     } else {
-                        instruction.operands[idx] = registerGenerator.next(
-                                a = RegisterType.Input,
-                                b = RegisterType.Calculation,
-                                predicate = { random.nextDouble() < 0.5 }
-                        ).first().index
+                        registerGenerator.next(
+                            a = RegisterType.Input,
+                            b = RegisterType.Calculation,
+                            predicate = { random.nextDouble() < 0.5 }
+                        ).first()
                     }
+
+                    instruction.operands[operand] = replacementRegister.index
                 }
             }
             MicroMutationType.Operator -> {
                 // 4. If operator mutation then select a different instruction operation randomly
-                val op = random.choice(this.operations)
+                val operation = random.choice(this.operations)
 
-                // Assure that the arity of the new operation matches with
-                // the number of operands the instruction has.
-                // If we're going to a reduced arity instruction, we can just truncate the operands
-                if (instruction.operands.size > op.arity.number) {
-                    instruction.operands = instruction.operands.slice(0 until op.arity.number)
-                } else if (instruction.operands.size < op.arity.number) {
+                // Assure that the arity of the new operation matches with the number of operands the instruction has.
+                // If the arity of the operations is the same, then nothing needs to be done.
+                if (instruction.operands.size > operation.arity.number) {
+                    // If we're going to a reduced arity instruction, we can just truncate the operands
+                    instruction.operands = instruction.operands.slice(0 until operation.arity.number)
+                } else if (instruction.operands.size < operation.arity.number) {
                     // Otherwise, if we're increasing the arity, just add random input
                     // and calculation registers until the arity is met.
-                    while (instruction.operands.size < op.arity.number) {
-                        val reg = if (random.nextDouble() < constantsRate) {
+                    while (instruction.operands.size < operation.arity.number) {
+                        val register = if (random.nextDouble() < constantsRate) {
                             registerGenerator.next(RegisterType.Constant).first()
                         } else {
                             registerGenerator.next(
-                                    a = RegisterType.Input,
-                                    b = RegisterType.Calculation,
-                                    predicate = { random.nextDouble() < 0.5 }
+                                a = RegisterType.Input,
+                                b = RegisterType.Calculation,
+                                predicate = { random.nextDouble() < 0.5 }
                             ).first()
                         }
 
-                        instruction.operands.add(reg.index)
+                        instruction.operands.add(register.index)
                     }
                 }
 
-                instruction.operation = op
+                instruction.operation = operation
             }
             else -> {
                 // 5. If constant mutation then
                 // (a) Randomly select an (effective) instruction with a constant c.
+                // Unfortunately the way of searching for an instruction that uses a constant is not
+                // particularly elegant, requiring a random search of the entire program.
                 var instr = random.choice(individual.effectiveInstructions)
                 var constantRegisters = instr.operands.filter { operand ->
                     individual.registers.registerType(operand) == RegisterType.Constant
                 }
 
+                // Arbitrarily limit the search to avoid entering a potentially infinite search.
                 var limit = 0
 
                 while (constantRegisters.isEmpty() && limit++ < individual.effectiveInstructions.size) {
@@ -289,7 +301,7 @@ class MicroMutationOperator<T>(
                     }
                 }
 
-                // Only do this if we found an instruction with a constant
+                // Only do this if we found an instruction with a constant before giving up.
                 if (limit < individual.effectiveInstructions.size) {
                     // (b) Change constant c through a standard deviation σ_const
                     // from the current value: c := c + N(0, σ_const)
@@ -298,8 +310,8 @@ class MicroMutationOperator<T>(
                     // should be used.
 
                     // Use the first operand that refers to a constant register.
-                    val reg = constantRegisters.first()
-                    val oldValue = individual.registers[reg]
+                    val register = constantRegisters.first()
+                    val oldValue = individual.registers[register]
 
                     // Compute a new value using the current constant register value.
                     val newValue = this.constantMutationFunc(oldValue)
@@ -307,7 +319,7 @@ class MicroMutationOperator<T>(
                     // Because each individual has its own register set, we can
                     // just overwrite the constant register value.
                     // TODO: Perhaps better to keep original constants for diversity?
-                    individual.registers.overwrite(reg, newValue)
+                    individual.registers.overwrite(register, newValue)
                 }
             }
         }
@@ -318,17 +330,16 @@ class MicroMutationOperator<T>(
 
 internal fun <T> findEffectiveCalculationRegisters(individual: Program<T>, stopPoint: Int): List<RegisterIndex> {
     val effectiveRegisters = mutableListOf(individual.outputRegisterIndex)
+    // Only instructions up until to the stop point should be searched.
+    val instructions = individual.instructions.reversed().filterIndexed { idx, _ -> idx < stopPoint }
 
-    for ((i, instruction) in individual.instructions.reversed().withIndex()) {
-        if (i == stopPoint)
-            break
-
+    instructions.forEach { instruction ->
         if (instruction.destination in effectiveRegisters) {
             effectiveRegisters.remove(instruction.destination)
 
-            for (operand in instruction.operands) {
-                val isCalculation = individual.registers.registerType(operand) == RegisterType.Calculation ||
-                        individual.registers.registerType(operand) == RegisterType.Input
+            instruction.operands.forEach { operand ->
+                val type = individual.registers.registerType(operand)
+                val isCalculation = type == RegisterType.Calculation || type == RegisterType.Input
 
                 if (operand !in effectiveRegisters && isCalculation) {
                     effectiveRegisters.add(operand)


### PR DESCRIPTION
This PR tidies up the `MutationOperator` class and its implementations. In terms of functionality, nothing has been changed -- but the internal implementation should now be easier to understand and also make use of Kotlin idioms.

As part of this work, the compiler xlint options were enabled to help ensure that there are no warnings being given. Moving forward, the build script will fail the build if any warnings are given. Related to this, some changes were made to address issues that were found after enabling compiler warnings.