### PR TITLE
Add logging abstractions and KotlinLogging implementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,9 @@ dependencies {
     // Used for CSV dataset file loading
     implementation("com.opencsv:opencsv:5.5.2")
 
+    // Logging
+    implementation("io.github.microutils:kotlin-logging-jvm:2.0.10")
+
     // Tests
     testImplementation("org.spekframework.spek2:spek-dsl-jvm:2.0.17")
     testRuntimeOnly("org.spekframework.spek2:spek-runner-junit5:2.0.17")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -59,7 +59,7 @@ java {
 
 tasks {
     val group = "nz.co.jedsimson.lgp"
-    val version = "5.2"
+    val version = "5.3"
 
     // Main library JAR.
     jar {

--- a/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/KotlinLoggingLogger.kt
+++ b/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/KotlinLoggingLogger.kt
@@ -1,0 +1,23 @@
+package nz.co.jedsimson.lgp.core.environment.logging
+
+import mu.KLogger
+import mu.KotlinLogging
+
+/**
+ * A [Logger] implementation using [KotlinLogging].
+ */
+internal class KotlinLoggingLogger(val name: String) : Logger {
+    private val kotlinLogger: KLogger = KotlinLogging.logger(name)
+
+    override fun trace(message: () -> Any?) = kotlinLogger.trace(message)
+
+    override fun debug(message: () -> Any?) = kotlinLogger.debug(message)
+
+    override fun info(message: () -> Any?) = kotlinLogger.info(message)
+
+    override fun warn(message: () -> Any?) = kotlinLogger.warn(message)
+
+    override fun error(message: () -> Any?) = kotlinLogger.error(message)
+
+    override fun error(throwable: Throwable, message: () -> Any?) = kotlinLogger.error(throwable, message)
+}

--- a/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/Logger.kt
+++ b/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/Logger.kt
@@ -1,10 +1,36 @@
 package nz.co.jedsimson.lgp.core.environment.logging
 
+/**
+ * Defines mechanisms for logging.
+ */
 interface Logger {
-    fun trace(msg: () -> Any?)
-    fun debug(msg: () -> Any?)
-    fun info(msg: () -> Any?)
-    fun warn(msg: () -> Any?)
-    fun error(msg: () -> Any?)
-    fun error(throwable: Throwable, msg: () -> Any?)
+    /**
+     * Writes [message] at the `Trace` level, if enabled.
+     */
+    fun trace(message: () -> Any?)
+
+    /**
+     * Writes [message] at the `Debug` level, if enabled.
+     */
+    fun debug(message: () -> Any?)
+
+    /**
+     * Writes [message] at the `Info` level, if enabled.
+     */
+    fun info(message: () -> Any?)
+
+    /**
+     * Writes [message] at the `Warn` level, if enabled.
+     */
+    fun warn(message: () -> Any?)
+
+    /**
+     * Writes [message] at the `Error` level, if enabled.
+     */
+    fun error(message: () -> Any?)
+
+    /**
+     * Writes [message] at the `Error` level with details of [throwable], if enabled.
+     */
+    fun error(throwable: Throwable, message: () -> Any?)
 }

--- a/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/Logger.kt
+++ b/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/Logger.kt
@@ -1,0 +1,10 @@
+package nz.co.jedsimson.lgp.core.environment.logging
+
+interface Logger {
+    fun trace(msg: () -> Any?)
+    fun debug(msg: () -> Any?)
+    fun info(msg: () -> Any?)
+    fun warn(msg: () -> Any?)
+    fun error(msg: () -> Any?)
+    fun error(throwable: Throwable, msg: () -> Any?)
+}

--- a/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/LoggerProvider.kt
+++ b/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/LoggerProvider.kt
@@ -1,32 +1,18 @@
 package nz.co.jedsimson.lgp.core.environment.logging
 
-import mu.KLogger
-import mu.KotlinLogging
-
-
+/**
+ * Provides access to a [Logger] instance.
+ */
 class LoggerProvider {
     companion object {
+        /**
+         * Gets a logger for [name].
+         */
         fun getLogger(name: String) = LoggerProvider().getLogger(name)
     }
 
-    fun getLogger(name: String): Logger
-    {
-        val kotlinLogger = KotlinLogging.logger(name)
-
-        return KotlinLoggingAdapter(kotlinLogger)
-    }
-
-    class KotlinLoggingAdapter(private val kotlinLogger: KLogger) : Logger {
-        override fun trace(msg: () -> Any?) = kotlinLogger.trace(msg)
-
-        override fun debug(msg: () -> Any?) = kotlinLogger.debug(msg)
-
-        override fun info(msg: () -> Any?) = kotlinLogger.info(msg)
-
-        override fun warn(msg: () -> Any?) = kotlinLogger.warn(msg)
-
-        override fun error(msg: () -> Any?) = kotlinLogger.error(msg)
-
-        override fun error(throwable: Throwable, msg: () -> Any?) = kotlinLogger.error(throwable, msg)
-    }
+    /**
+     * Gets a logger for [name].
+     */
+    fun getLogger(name: String): Logger = KotlinLoggingLogger(name)
 }

--- a/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/LoggerProvider.kt
+++ b/src/main/kotlin/nz/co/jedsimson/lgp/core/environment/logging/LoggerProvider.kt
@@ -1,0 +1,32 @@
+package nz.co.jedsimson.lgp.core.environment.logging
+
+import mu.KLogger
+import mu.KotlinLogging
+
+
+class LoggerProvider {
+    companion object {
+        fun getLogger(name: String) = LoggerProvider().getLogger(name)
+    }
+
+    fun getLogger(name: String): Logger
+    {
+        val kotlinLogger = KotlinLogging.logger(name)
+
+        return KotlinLoggingAdapter(kotlinLogger)
+    }
+
+    class KotlinLoggingAdapter(private val kotlinLogger: KLogger) : Logger {
+        override fun trace(msg: () -> Any?) = kotlinLogger.trace(msg)
+
+        override fun debug(msg: () -> Any?) = kotlinLogger.debug(msg)
+
+        override fun info(msg: () -> Any?) = kotlinLogger.info(msg)
+
+        override fun warn(msg: () -> Any?) = kotlinLogger.warn(msg)
+
+        override fun error(msg: () -> Any?) = kotlinLogger.error(msg)
+
+        override fun error(throwable: Throwable, msg: () -> Any?) = kotlinLogger.error(throwable, msg)
+    }
+}


### PR DESCRIPTION
This PR adds the initial work to resolve #17.

- Added `Logger` abstraction which provides the core logging mechanisms for framework components
- Added `LoggerProvider` which the system can rely on to provide access to a `Logger` instance
- Initial `LoggerProvider` implementation uses [kotlin-logging](https://github.com/MicroUtils/kotlin-logging) as the underlying logger